### PR TITLE
Add metager domains

### DIFF
--- a/domains
+++ b/domains
@@ -17,6 +17,9 @@ hmsearx.h0meserver.com
 jsearch.pw
 lukol.com
 metacrawler.com
+metager3.de
+metager.de
+metager.org
 metasearch.nl
 mijisou.com
 mojeek.com


### PR DESCRIPTION
MetaGer is a metasearch engine that uses Yahoo for example.

Refer to: https://en.wikipedia.org/wiki/MetaGer  ,  https://metager.org/meta/settings?fokus=web&url=https%3A%2F%2Fmetager.org