### PR TITLE
Add result domains of metasearch engine excite

### DIFF
--- a/domains
+++ b/domains
@@ -34,6 +34,7 @@ peekier.com
 ransack.i2p
 recherche.aol.fr
 recherche.catmargue.org
+results.excite.com
 roteserver.de
 search.0xcb.dev
 search.activemail.de
@@ -161,6 +162,7 @@ tromland.org
 trovu.komun.org
 unmonito.red
 webcrawler.com
+websearch.excite.co.jp
 wtf.roflcopter.fr
 www.finden.tk
 www.gruble.de


### PR DESCRIPTION
Excite is more than a metasearch engine. So we should just block the result pages.

Refer to https://en.wikipedia.org/wiki/Excite_(web_portal)