### PR TITLE
Add Qwant Lite

### DIFF
--- a/domains
+++ b/domains
@@ -15,6 +15,7 @@ haku.ahmia.fi
 haku.lelux.fi
 hmsearx.h0meserver.com
 jsearch.pw
+lite.qwant.com
 lukol.com
 metacrawler.com
 metager3.de


### PR DESCRIPTION
Although Qwant supports safesearch, Qwant Lite doesn't.

Refer to https://lite.qwant.com https://lite.qwant.com/settings?l=en