### PR TITLE
Add onesearch.com

### DIFF
--- a/domains
+++ b/domains
@@ -29,6 +29,7 @@ nibblehole.com
 nigma.eu
 nova.rambler.ru
 null.media
+onesearch.com
 openworlds.info
 oscobo.com
 peekier.com


### PR DESCRIPTION
Onesearch is also mentioned in https://github.com/nextdns/no-safesearch/issues/1

Refer to https://www.onesearch.com/