### PR TITLE
Add 10 unblocked and well-known searx domains

### DIFF
--- a/domains
+++ b/domains
@@ -37,6 +37,7 @@ recherche.aol.fr
 recherche.catmargue.org
 results.excite.com
 roteserver.de
+s.frlt.one
 search.0xcb.dev
 search.activemail.de
 search.anonymize.com
@@ -47,11 +48,13 @@ search.azkware.net
 search.biboumail.fr
 search.bluelock.org
 search.brave.com
+search.chemicals-in-the-water.eu
 search.disroot.org
 search.ethibox.fr
 search.gougeul.org
 search.jigsaw-security.com
 search.jpope.org
+search.kiwitalk.de
 search.lgbtq.cool
 search.mdosch.de
 search.modalogi.com
@@ -59,11 +62,14 @@ search.nebulacentre.net
 search.opentunisia.org
 search.paulla.asso.fr
 search.privacytools.io
+search.rhscz.eu
+search.sapti.me
 search.seds.nl
 search.snopyta.org
 search.spaeth.me
 search.st8.at
 search.stinpriza.org
+search.unlocked.link
 search.yahoo.com
 searchencrypt.com
 searchx.mobi
@@ -73,6 +79,7 @@ searx.bar
 searx.bbaovanc.com
 searx.be
 searx.canox.net
+searx.catfluori.de
 searx.ch
 searx.com.au
 searx.decatec.de
@@ -133,6 +140,7 @@ searx.ru
 searx.run
 searx.rxyz.rocks
 searx.semipvt.com
+searx.si
 searx.simonoener.com
 searx.slash-dev.de
 searx.solusar.de
@@ -140,11 +148,13 @@ searx.sp-codes.de
 searx.sulu.me
 searx.sunless.cloud
 searx.thegreenwebfoundation.org
+searx.tiekoetter.com
 searx.tuxcloud.net
 searx.tyil.nl
 searx.vitanetworks.link
 searx.wegeeks.win
 searx.win
+searx.work
 searx.xyz
 searx.zapashcanon.fr
 searx.zdechov.net


### PR DESCRIPTION
Add first chunk of yet unblocked and well known searx(ng) domains.

https://s.frlt.one/
https://search.chemicals-in-the-water.eu/
https://search.kiwitalk.de/
https://search.rhscz.eu/
https://search.sapti.me/
https://search.unlocked.link/
https://searx.catfluori.de/
https://searx.si/
https://searx.tiekoetter.com/
https://searx.work/