### PR TITLE
Removes Brave Search

### DIFF
--- a/domains
+++ b/domains
@@ -46,7 +46,6 @@ search.aol.com
 search.azkware.net
 search.biboumail.fr
 search.bluelock.org
-search.brave.com
 search.disroot.org
 search.ethibox.fr
 search.gougeul.org


### PR DESCRIPTION
Brave Search supports _Safe Search_, which is also _enabled by default_.