### PR TITLE
Add meta search engine eTools.ch

### DIFF
--- a/domains
+++ b/domains
@@ -6,6 +6,7 @@ dogpile.com
 dynabyte.ca
 ecosia.org
 engo.mint.lgbt
+etools.ch
 eulie.de
 fireball.de
 gibiru.com
@@ -22,6 +23,7 @@ metager3.de
 metager.de
 metager.org
 metasearch.nl
+metasearch.ch
 mijisou.com
 mojeek.com
 neeva.com
@@ -157,6 +159,7 @@ suche.aol.de
 suche.dasnetzundich.de
 suche.mexmail.de
 suche.uferwerk.org
+sucher.ch
 suchfeuer.de
 timdor.noip.me
 tromland.org
@@ -165,10 +168,13 @@ unmonito.red
 webcrawler.com
 websearch.excite.co.jp
 wtf.roflcopter.fr
+www.etools.ch
 www.finden.tk
 www.gruble.de
+www.metasearch.ch
 www.perfectpixel.de
 www.searxs.eu
+www.sucher.ch
 yep.com
 yippy.com
 you.com


### PR DESCRIPTION
The website etools.ch offers a safesearch option. However it is disabled by default. Furthermore, this website contains advertisements by default and if all of them are suitable for children is at least questionable. For example, I got an discreet advertisement for an online sex store on my first visit. 

Additionally added domains are mentioned on the help page directly.

Further information is available at:

	https://www.etools.ch/searchInfo.do
	https://www.etools.ch/searchHelp.do