### PR TITLE
Add meta search engine tiger.ch

### DIFF
--- a/domains
+++ b/domains
@@ -158,6 +158,7 @@ suche.dasnetzundich.de
 suche.mexmail.de
 suche.uferwerk.org
 suchfeuer.de
+tiger.ch
 timdor.noip.me
 tromland.org
 trovu.komun.org


### PR DESCRIPTION
Tiger doesn't even has a setting to activate safesearch.

Further information is available at

	https://tiger.ch/About