### PR TITLE
Removes Mojeek

### DIFF
--- a/domains
+++ b/domains
@@ -23,7 +23,6 @@ metager.de
 metager.org
 metasearch.nl
 mijisou.com
-mojeek.com
 neeva.com
 nibblehole.com
 nigma.eu


### PR DESCRIPTION
Mojeek supports _Safe Search_. This can be used through:

- the safe=1 parameter, like so: https://www.mojeek.com/?safe=1;
- toggling the option on in [Preferences](https://www.mojeek.com/preferences); or
- using the gear icon ⚙️ on the Search Engine Results Page. 