### PR TITLE
Remove ecosia.org as it has a safesearch option

### DIFF
--- a/domains
+++ b/domains
@@ -4,7 +4,6 @@ boomle.com
 darmarit.org
 dogpile.com
 dynabyte.ca
-ecosia.org
 engo.mint.lgbt
 eulie.de
 fireball.de


### PR DESCRIPTION
This search engine has its own safe search option in the settings.